### PR TITLE
Implement Basic Date Recognition

### DIFF
--- a/src/main/java/com/timenlp/parser/DateParser.java
+++ b/src/main/java/com/timenlp/parser/DateParser.java
@@ -1,9 +1,28 @@
 package com.timenlp.parser;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+
 public class DateParser {
 
-    public String parse(String text) {
-        // TODO: Implement date parsing logic
-        return null;
+    private static final DateTimeFormatter YYYY_MM_DD = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter MM_DD_YYYY = DateTimeFormatter.ofPattern("MM/dd/yyyy");
+
+    public Optional<LocalDate> parseDate(String dateString) {
+        try {
+            return Optional.of(LocalDate.parse(dateString, YYYY_MM_DD));
+        } catch (DateTimeParseException e) {
+            // Ignore and try the next format
+        }
+
+        try {
+            return Optional.of(LocalDate.parse(dateString, MM_DD_YYYY));
+        } catch (DateTimeParseException e) {
+            // Ignore and return empty Optional
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/test/java/com/timenlp/parser/DateParserTest.java
+++ b/src/test/java/com/timenlp/parser/DateParserTest.java
@@ -1,14 +1,40 @@
 package com.timenlp.parser;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
-public class DateParserTest {
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DateParserTest {
+
+    private final DateParser dateParser = new DateParser();
 
     @Test
-    public void testParse() {
-        DateParser dateParser = new DateParser();
-        // TODO: Implement test cases
-        assertNull(dateParser.parse("test"));
+    void parseDate_yyyy_MM_dd() {
+        Optional<LocalDate> date = dateParser.parseDate("2023-10-26");
+        assertTrue(date.isPresent());
+        assertEquals(LocalDate.of(2023, 10, 26), date.get());
     }
+
+    @Test
+    void parseDate_MM_dd_yyyy() {
+        Optional<LocalDate> date = dateParser.parseDate("10/26/2023");
+        assertTrue(date.isPresent());
+        assertEquals(LocalDate.of(2023, 10, 26), date.get());
+    }
+
+    @Test
+    void parseDate_invalidFormat() {
+        Optional<LocalDate> date = dateParser.parseDate("2023/10/26");
+        assertFalse(date.isPresent());
+    }
+
+    @Test
+    void parseDate_emptyString() {
+        Optional<LocalDate> date = dateParser.parseDate("");
+        assertFalse(date.isPresent());
+    }
+
 }


### PR DESCRIPTION
This Pull Request implements basic date recognition and parsing functionality for simple date formats: 'yyyy-MM-dd' and 'MM/dd/yyyy'.

**Changes:**

*   Created a `DateParser` class with a `parseDate` method.
*   The `parseDate` method attempts to parse the input string using two predefined `DateTimeFormatter` instances for the supported formats.
*   If parsing is successful with either format, the method returns an `Optional<LocalDate>` containing the parsed date.
*   If parsing fails for both formats, the method returns an empty `Optional<LocalDate>`.
*   Added unit tests using JUnit 5 to verify the parsing logic for both supported formats, invalid formats, and empty strings.

**Testing:**

The following test cases are included in `DateParserTest.java`:

*   `parseDate_yyyy_MM_dd`: Tests parsing of dates in 'yyyy-MM-dd' format.
*   `parseDate_MM_dd_yyyy`: Tests parsing of dates in 'MM/dd/yyyy' format.
*   `parseDate_invalidFormat`: Tests parsing of dates with an unsupported format (e.g., 'yyyy/MM/dd').
*   `parseDate_emptyString`: Tests parsing of an empty string.

All tests pass, demonstrating the correct functionality of the date parsing logic.

This implementation uses `java.time.LocalDate` and `java.time.format.DateTimeFormatter` for date representation and parsing, providing a more robust and modern approach compared to older date/time APIs.