### PR TITLE
Implement 'Today', 'Tomorrow', 'Yesterday' Parsing

### DIFF
--- a/src/main/java/com/timenlp/parser/RelativeTimeParser.java
+++ b/src/main/java/com/timenlp/parser/RelativeTimeParser.java
@@ -1,9 +1,23 @@
 package com.timenlp.parser;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class RelativeTimeParser {
 
-    public String parse(String text) {
-        // TODO: Implement relative time parsing logic
-        return null;
+    public String parse(String input) {
+        LocalDate today = LocalDate.now();
+
+        if (input.equalsIgnoreCase("today")) {
+            return today.format(DateTimeFormatter.ISO_LOCAL_DATE);
+        } else if (input.equalsIgnoreCase("tomorrow")) {
+            return today.plusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        } else if (input.equalsIgnoreCase("yesterday")) {
+            return today.minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        } else {
+            return null; // Indicate that the input could not be parsed as a relative date.
+        }
     }
 }

--- a/src/test/java/com/timenlp/parser/RelativeTimeParserTest.java
+++ b/src/test/java/com/timenlp/parser/RelativeTimeParserTest.java
@@ -1,0 +1,41 @@
+package com.timenlp.parser;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RelativeTimeParserTest {
+
+    @Test
+    void parseToday() {
+        RelativeTimeParser parser = new RelativeTimeParser();
+        String expected = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        assertEquals(expected, parser.parse("today"));
+        assertEquals(expected, parser.parse("Today"));
+    }
+
+    @Test
+    void parseTomorrow() {
+        RelativeTimeParser parser = new RelativeTimeParser();
+        String expected = LocalDate.now().plusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        assertEquals(expected, parser.parse("tomorrow"));
+        assertEquals(expected, parser.parse("Tomorrow"));
+    }
+
+    @Test
+    void parseYesterday() {
+        RelativeTimeParser parser = new RelativeTimeParser();
+        String expected = LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        assertEquals(expected, parser.parse("yesterday"));
+        assertEquals(expected, parser.parse("Yesterday"));
+    }
+
+    @Test
+    void parseInvalidInput() {
+        RelativeTimeParser parser = new RelativeTimeParser();
+        assertNull(parser.parse("invalid"));
+    }
+}


### PR DESCRIPTION
This Pull Request implements the requested feature of parsing relative time expressions like 'Today', 'Tomorrow', and 'Yesterday'.

**Changes:**

*   Added a `parse` method to the `RelativeTimeParser` class that takes a string as input and returns the corresponding date in ISO_LOCAL_DATE format (YYYY-MM-DD) if the input is 'today', 'tomorrow', or 'yesterday' (case-insensitive).
*   If the input is 'today', it returns the current date.
*   If the input is 'tomorrow', it returns the date one day after the current date.
*   If the input is 'yesterday', it returns the date one day before the current date.
*   If the input doesn't match any of the supported keywords, it returns `null` to indicate parsing failure.
*   Added unit tests in `RelativeTimeParserTest` to test the `parse` method with different inputs, including 'today', 'tomorrow', 'yesterday' (and their capitalized variants), and an invalid input.

**Reasoning:**

This feature allows users to express time in a more natural and user-friendly way. The implementation uses `java.time.LocalDate` and `java.time.format.DateTimeFormatter` for date handling, ensuring thread safety and adherence to modern date/time API standards.

**Testing:**

The included unit tests cover the following scenarios:

*   Parsing 'today' (and 'Today') correctly.
*   Parsing 'tomorrow' (and 'Tomorrow') correctly.
*   Parsing 'yesterday' (and 'Yesterday') correctly.
*   Handling invalid input by returning `null`.

All tests pass successfully, demonstrating the correct functionality of the implemented feature.